### PR TITLE
Expand actor study schemas

### DIFF
--- a/character_dossier_expanded_method_i.json
+++ b/character_dossier_expanded_method_i.json
@@ -8,33 +8,72 @@
     "source_material": { "type": "string" },
     "blueprint": {
       "type": "object",
+      "description": "Phase I - Textual analysis using Stanislavski's approach",
       "properties": {
-        "biographical_summary": { "type": "string" },
-        "core_contradictions": {
+        "verifiable_facts": {
           "type": "array",
+          "description": "Objective facts drawn from the text",
           "items": { "type": "string" }
         },
-        "linguistic_fingerprint": {
+        "contradiction_log": {
+          "type": "array",
+          "description": "Conflicting statements and actions",
+          "items": {
+            "type": "object",
+            "properties": {
+              "claim": { "type": "string" },
+              "conflicts_with": { "type": "string" }
+            },
+            "required": ["claim", "conflicts_with"]
+          }
+        },
+        "linguistic_profile": {
           "type": "object",
           "properties": {
-            "syntax": { "type": "string" },
-            "pacing": { "type": "string" },
-            "lexical_choices": {
+            "vocabulary_syntax": { "type": "string" },
+            "rhythm_imagery": { "type": "string" }
+          },
+          "required": ["vocabulary_syntax", "rhythm_imagery"]
+        },
+        "objective_action_analysis": {
+          "type": "object",
+          "properties": {
+            "super_objective": { "type": "string" },
+            "tactics": {
               "type": "array",
               "items": { "type": "string" }
             }
           },
-          "required": ["syntax", "pacing", "lexical_choices"]
+          "required": ["super_objective"]
+        },
+        "relationship_mapping": {
+          "type": "array",
+          "description": "Sociogram with emotional currency",
+          "items": {
+            "type": "object",
+            "properties": {
+              "character": { "type": "string" },
+              "emotional_currency": { "type": "string" }
+            },
+            "required": ["character", "emotional_currency"]
+          }
         }
       },
-      "required": ["biographical_summary", "core_contradictions", "linguistic_fingerprint"]
+      "required": [
+        "verifiable_facts",
+        "linguistic_profile",
+        "objective_action_analysis",
+        "relationship_mapping"
+      ]
     },
     "inner_world": {
       "type": "object",
+      "description": "Phase I - Psychological and imaginative work",
       "properties": {
-        "super_objective": { "type": "string" },
-        "primal_fear": { "type": "string" },
-        "central_paradox": { "type": "string" },
+        "backstory": {
+          "type": "string",
+          "description": "Emotional turning points shaping the character"
+        },
         "memory_journal": {
           "type": "array",
           "items": {
@@ -42,24 +81,64 @@
             "properties": {
               "event": { "type": "string" },
               "emotion": { "type": "string" },
+              "sensory_anchor": { "type": "string" },
               "influence_on_present": { "type": "string" }
             },
-            "required": ["event", "emotion", "influence_on_present"]
+            "required": ["event", "emotion", "sensory_anchor", "influence_on_present"]
           }
+        },
+        "core_motivation": { "type": "string" },
+        "primal_fear": { "type": "string" },
+        "primary_defense_mechanism": { "type": "string" },
+        "central_paradox": { "type": "string" },
+        "magic_if": {
+          "type": "string",
+          "description": "Stanislavski's refined Magic If"
         }
       },
-      "required": ["super_objective", "primal_fear", "central_paradox"]
+      "required": [
+        "core_motivation",
+        "primal_fear",
+        "primary_defense_mechanism",
+        "central_paradox",
+        "magic_if"
+      ]
     },
     "physical_form": {
       "type": "object",
+      "description": "Phase I - External embodiment using animal work and Chekhov technique",
       "properties": {
-        "animal_work": { "type": "string" },
-        "energetic_center": { "type": "string" }
+        "animal_work": {
+          "type": "object",
+          "properties": {
+            "animal": { "type": "string" },
+            "effort_rhythm": { "type": "string" },
+            "translated_human_quality": { "type": "string" }
+          },
+          "required": ["animal", "effort_rhythm", "translated_human_quality"]
+        },
+        "chekhov_technique": {
+          "type": "object",
+          "properties": {
+            "energetic_center": { "type": "string" },
+            "imaginary_body": {
+              "type": "object",
+              "properties": {
+                "posture": { "type": "string" },
+                "weight_distribution": { "type": "string" },
+                "tension_patterns": { "type": "string" }
+              },
+              "required": ["posture", "weight_distribution", "tension_patterns"]
+            }
+          },
+          "required": ["energetic_center", "imaginary_body"]
+        }
       },
-      "required": ["animal_work", "energetic_center"]
+      "required": ["animal_work", "chekhov_technique"]
     },
     "method_work": {
       "type": "object",
+      "description": "References to acting techniques used",
       "properties": {
         "stanislavski": {
           "type": "object",
@@ -113,5 +192,14 @@
       "required": ["stanislavski", "uta_hagen", "chekhov", "practical_aesthetics"]
     }
   },
-  "required": ["name", "role", "source_material", "blueprint", "inner_world", "physical_form", "method_work"]
+  "required": [
+    "name",
+    "role",
+    "source_material",
+    "blueprint",
+    "inner_world",
+    "physical_form",
+    "method_work"
+  ]
 }
+

--- a/in_scene_grounding_schema.json
+++ b/in_scene_grounding_schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "In-Scene Grounding (Phase II - Method I Acting)",
+  "type": "object",
+  "properties": {
+    "pre_scene_checklist": {
+      "type": "object",
+      "description": "Uta Hagen's Five-Second Reality Check",
+      "properties": {
+        "where_am_i": { "type": "string" },
+        "what_time_is_it": { "type": "string" },
+        "what_surrounds_me": { "type": "string" },
+        "moment_before": { "type": "string" },
+        "immediate_objective": { "type": "string" },
+        "first_move": { "type": "string" }
+      },
+      "required": [
+        "where_am_i",
+        "moment_before",
+        "immediate_objective",
+        "first_move"
+      ]
+    },
+    "in_scene_activation": {
+      "type": "object",
+      "properties": {
+        "tactics": {
+          "type": "array",
+          "description": "Practical Aesthetics - play the action",
+          "items": { "type": "string" }
+        },
+        "sensory_engagement": {
+          "type": "object",
+          "description": "Stanislavski's sensory work",
+          "properties": {
+            "sight": { "type": "string" },
+            "sound": { "type": "string" },
+            "touch": { "type": "string" },
+            "smell": { "type": "string" },
+            "taste": { "type": "string" }
+          }
+        },
+        "partner_influence": {
+          "type": "string",
+          "description": "Meisner-inspired responsiveness"
+        }
+      },
+      "required": ["tactics", "partner_influence"]
+    }
+  },
+  "required": ["pre_scene_checklist", "in_scene_activation"]
+}
+


### PR DESCRIPTION
## Summary
- enrich character dossier schema with detailed blueprint, inner world, and physical form fields tied to acting techniques
- add in-scene grounding schema modeling pre-scene checklist and in-performance activation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890624ee3248332897d4479eed3b70c