### PR TITLE
Add retrieval helpers to LivingDossier

### DIFF
--- a/list_index.py
+++ b/list_index.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass, field
+from typing import Iterable, List, Tuple
+
+
+@dataclass
+class ListIndex:
+    """Simple in-memory index of strings.
+
+    Parameters
+    ----------
+    items:
+        An iterable of strings to index.
+    """
+
+    items: Iterable[str] = field(default_factory=list)
+
+    def search(self, keyword: str) -> List[Tuple[int, str]]:
+        """Return items containing ``keyword`` ranked by occurrence count.
+
+        The search is intentionally naive and performs a case-insensitive
+        substring match.  Each matching item is paired with a score equal to
+        the number of times the keyword occurs within that item.
+
+        Parameters
+        ----------
+        keyword:
+            Term to look for within the indexed items.
+
+        Returns
+        -------
+        List[Tuple[int, str]]
+            Tuples of ``(score, item)`` sorted by ``score`` descending.
+
+        Example
+        -------
+        >>> idx = ListIndex(["I love pizza", "I love pasta"])
+        >>> idx.search("pizza")
+        [(1, 'I love pizza')]
+
+        Notes
+        -----
+        This is placeholder logic and should be replaced with a more robust
+        search implementation.
+        """
+        keyword_lower = keyword.lower()
+        results: List[Tuple[int, str]] = []
+        for item in self.items:
+            count = item.lower().count(keyword_lower)
+            if count:
+                results.append((count, item))
+        results.sort(key=lambda x: x[0], reverse=True)
+        return results

--- a/living_dossier.py
+++ b/living_dossier.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass, field
+from typing import Iterable, List, Tuple
+
+from list_index import ListIndex
+
+
+@dataclass
+class LivingDossier:
+    """Container for a character's memories and linguistic traits.
+
+    Parameters
+    ----------
+    memories:
+        Iterable of memory strings.
+    linguistic_traits:
+        Iterable of linguistic trait strings.
+    """
+
+    memories: Iterable[str] = field(default_factory=list)
+    linguistic_traits: Iterable[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.memory_index = ListIndex(self.memories)
+        self.linguistic_trait_index = ListIndex(self.linguistic_traits)
+
+    def retrieve_memories(self, keyword: str) -> List[Tuple[int, str]]:
+        """Search ``memories`` for ``keyword`` and return ranked results.
+
+        Delegates to :meth:`ListIndex.search` on the memory index.  The ranking
+        score is derived from a naive substring match.
+
+        Parameters
+        ----------
+        keyword:
+            Term to look for.
+
+        Returns
+        -------
+        List[Tuple[int, str]]
+            Tuples of ``(score, memory)`` sorted by ``score`` descending.
+
+        Example
+        -------
+        >>> dossier = LivingDossier(memories=["Enjoys pizza", "Likes pasta"])
+        >>> dossier.retrieve_memories("pizza")
+        [(1, 'Enjoys pizza')]
+
+        Notes
+        -----
+        The underlying search is placeholder logic and should be replaced with
+        a more sophisticated ranking algorithm.
+        """
+        return self.memory_index.search(keyword)
+
+    def retrieve_linguistic_traits(self, keyword: str) -> List[Tuple[int, str]]:
+        """Search ``linguistic_traits`` for ``keyword`` and return ranked results.
+
+        Delegates to :meth:`ListIndex.search` on the linguistic trait index.
+
+        Parameters
+        ----------
+        keyword:
+            Term to look for.
+
+        Returns
+        -------
+        List[Tuple[int, str]]
+            Tuples of ``(score, trait)`` sorted by ``score`` descending.
+
+        Example
+        -------
+        >>> dossier = LivingDossier(linguistic_traits=["uses slang", "formal"])
+        >>> dossier.retrieve_linguistic_traits("slang")
+        [(1, 'uses slang')]
+
+        Notes
+        -----
+        The underlying search is placeholder logic and should be replaced with
+        a more sophisticated ranking algorithm.
+        """
+        return self.linguistic_trait_index.search(keyword)

--- a/tests/test_living_dossier.py
+++ b/tests/test_living_dossier.py
@@ -1,0 +1,21 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from living_dossier import LivingDossier
+
+
+def test_retrieve_memories_ranks_by_occurrence():
+    dossier = LivingDossier(
+        memories=[
+            "Loves pizza",
+            "Pizza is delicious and pizza is life",
+            "Enjoys pasta",
+        ]
+    )
+    results = dossier.retrieve_memories("pizza")
+    assert results[0][1] == "Pizza is delicious and pizza is life"
+    assert results[0][0] > results[1][0]
+
+
+def test_retrieve_linguistic_traits():
+    dossier = LivingDossier(linguistic_traits=["uses slang", "formal tone"])
+    assert dossier.retrieve_linguistic_traits("slang") == [(1, "uses slang")]


### PR DESCRIPTION
## Summary
- add `ListIndex` for placeholder keyword ranking
- expose `LivingDossier.retrieve_memories` and `.retrieve_linguistic_traits` to delegate searches
- test retrieval ranking for memories and linguistic traits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68906a7e72648332bd5d808b05fd58b4