### PR TITLE
feat: add LLM config and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,21 @@
 
 This repository hosts design documents for the Method I Narrative Engine. See [ROADMAP.md](ROADMAP.md) for the implementation plan derived from section 8 of the main design document.
 
+## LLM Configuration
+
+Default parameters for LLM calls live in `config/llm.yaml`.
+The `LLMClient` class reads this file to determine the model,
+temperature, and token limits. These defaults can be overridden at
+runtime by passing explicit values to `LLMClient.generate()`.
+
+### Environment variables
+
+The client expects the following variables to be present:
+
+| Variable        | Purpose                                             |
+| --------------- | --------------------------------------------------- |
+| `OPENAI_API_KEY`| API key used when invoking the OpenAI SDK.          |
+| `LLM_MODEL`     | *(optional)* Overrides the model defined in the config file. |
+
+Set these variables in your environment before running code that calls the LLM.
+

--- a/config/llm.yaml
+++ b/config/llm.yaml
@@ -1,0 +1,3 @@
+model: gpt-4o-mini
+temperature: 0.7
+max_tokens: 1024

--- a/llm_client.py
+++ b/llm_client.py
@@ -1,0 +1,49 @@
+import os
+from typing import Optional
+
+import yaml
+
+
+class LLMClient:
+    """Simple LLM client that loads default parameters from a config file."""
+
+    def __init__(self, config_path: str = "config/llm.yaml") -> None:
+        with open(config_path, "r", encoding="utf-8") as f:
+            self.config = yaml.safe_load(f) or {}
+
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        # Allow environment variable override for the model
+        self.model = os.getenv("LLM_MODEL", self.config.get("model"))
+        self.temperature = self.config.get("temperature", 0.7)
+        self.max_tokens = self.config.get("max_tokens", 1024)
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Generate a completion for the given prompt.
+
+        Parameters can override the defaults loaded from configuration.
+        """
+        model = model or self.model
+        temperature = temperature or self.temperature
+        max_tokens = max_tokens or self.max_tokens
+
+        try:
+            import openai
+        except ImportError as exc:  # pragma: no cover - import guard
+            raise RuntimeError("openai package is required to generate text") from exc
+
+        openai.api_key = self.api_key
+
+        response = openai.ChatCompletion.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return response["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary
- add configurable LLM client that reads defaults from `config/llm.yaml`
- support overriding model, temperature, and max tokens via parameters and env vars
- document required environment variables for LLM access

## Testing
- `python -m py_compile llm_client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68907135847c83328ec03b6290b521ed