### PR TITLE
docs: document LLM provider setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,40 @@ The client recognises the following variables:
 | `LLM_TIMEOUT`      | value from config (`30`)    | Request timeout in seconds.     |
 | `OPENAI_API_KEY`   | `null`                      | API key for the OpenAI provider.|
 | `OPENAI_BASE_URL`  | `https://api.openai.com/v1` | Endpoint for the OpenAI API.    |
+| `OLLAMA_BASE_URL`  | `http://localhost:11434`    | Ollama base URL.                |
 
 Provider-specific variables use the pattern `<PROVIDER>_API_KEY` and
 `<PROVIDER>_BASE_URL`.
 
 Set these variables in your environment before running code that calls the
 LLM.
+
+### Switching providers
+
+Choose a provider with `LLM_PROVIDER` and set any required credentials:
+
+```bash
+# OpenAI
+export LLM_PROVIDER=openai
+export OPENAI_API_KEY=sk-...
+
+# Local Ollama server
+export LLM_PROVIDER=ollama
+export OLLAMA_BASE_URL=http://localhost:11434
+```
+
+### Troubleshooting
+
+**OpenAI**
+
+- `401 Unauthorized` – check that `OPENAI_API_KEY` is valid and not expired.
+- Connection errors – confirm `OPENAI_BASE_URL` and network access.
+
+**Ollama**
+
+- `Connection refused` – ensure the Ollama server is running at
+  `OLLAMA_BASE_URL`.
+- `404` or `model not found` – pull the model or verify its name.
 
 ## Development Progress (Tasks 2–4)
 - **Task 2:** Established the core scene generation loop that retrieves context and constructs prompts.
@@ -46,6 +74,7 @@ LLM.
 The pipeline expects the following variables at runtime:
 
 - `OPENAI_API_KEY` – API key for accessing the LLM provider.
+- `OLLAMA_BASE_URL` – Base URL for a local Ollama server.
 - `LLM_PROVIDER` – Name of the LLM provider (default `openai`).
 - `LLM_MODEL` – Model name used for inner monologue and dialogue.
 - `LLM_TEMPERATURE` – Sampling temperature for generation.

--- a/backend/llm/README.md
+++ b/backend/llm/README.md
@@ -1,0 +1,34 @@
+# LLM Module
+
+The `backend.llm` package houses utilities for talking to language model
+providers.
+
+## Architecture
+
+- `client.py` offers `LLMClient`, a minimal HTTP wrapper with retry and
+  exponential backoff. It reads `LLM_API_KEY` and `LLM_API_URL` from the
+  environment.
+- The repository-level `llm_client.py` builds on this, loading defaults from
+  `config/llm.yaml` and exposing a `from_config` constructor that selects
+  provider, model, and timeouts.
+
+## Switching providers
+
+`llm_client.LLMClient` chooses a provider from `config/llm.yaml` or the
+`LLM_PROVIDER` environment variable. Each provider supplies its own API key and
+base URL. To swap backends:
+
+```bash
+# OpenAI
+export LLM_PROVIDER=openai
+export OPENAI_API_KEY=sk-...
+
+# Local Ollama server
+export LLM_PROVIDER=ollama
+export OLLAMA_BASE_URL=http://localhost:11434
+```
+
+Provider variables follow the pattern `<PROVIDER>_API_KEY` and
+`<PROVIDER>_BASE_URL`, so additional providers can be added by extending the
+YAML file and setting matching environment variables.
+


### PR DESCRIPTION
## Summary
- document LLM client architecture and provider switching
- expand root README with provider setup, env vars, and troubleshooting

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json https://json-schema.org/draft-07/schema` *(fails: schema not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68907fafa4488332b7185c42bf49a952