### PR TITLE
Implement LLM-powered character extraction

### DIFF
--- a/backend/casting/models.py
+++ b/backend/casting/models.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class CharacterCandidate:
+    """Represents an extracted character candidate."""
+    name: str

--- a/backend/casting/prompts.py
+++ b/backend/casting/prompts.py
@@ -1,0 +1,8 @@
+"""Prompt templates for the casting subsystem."""
+
+CASTING_DIRECTOR_PROMPT = (
+    "You are a casting director extracting character names from prose. "
+    "Given the following text, respond with a JSON object containing a "
+    "'characters' list. Each entry must be an object with a 'name' field. "
+    "Return only valid JSON.\n\nText:\n"
+)

--- a/tests/test_casting_pipeline.py
+++ b/tests/test_casting_pipeline.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.casting.pipeline import CharacterExtractionPipeline
+from backend.casting.models import CharacterCandidate
+
+
+class DummyLLMClient:
+    def generate(self, prompt: str):
+        return {"characters": [{"name": "Alice"}, {"name": "Bob"}]}
+
+
+def test_extract_characters_parses_candidates():
+    pipeline = CharacterExtractionPipeline(llm_client=DummyLLMClient())
+    candidates = pipeline.extract_characters(["chunk one", "chunk two"])
+    assert candidates == [
+        CharacterCandidate(name="Alice"),
+        CharacterCandidate(name="Bob"),
+        CharacterCandidate(name="Alice"),
+        CharacterCandidate(name="Bob"),
+    ]


### PR DESCRIPTION
## Summary
- add casting director prompt template and `CharacterCandidate` model
- integrate `LLMClient.generate` into character extraction pipeline
- test character extraction flow

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json https://json-schema.org/draft-07/schema` *(fails: 'https://json-schema.org/draft-07/schema' does not exist)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68908271e97083328461536765e131b3