### PR TITLE
Add time-limited scene runner with termination reasons

### DIFF
--- a/tests/test_scene_pipeline.py
+++ b/tests/test_scene_pipeline.py
@@ -20,3 +20,17 @@ def test_update_state_adds_dialogue_and_actions():
     assert state.history[-1]["dialogue"]["speaker"] == "A"
     assert state.history[-1]["actions"] == ["wave"]
     assert state.turn == 1
+
+
+def test_run_scene_respects_max_turns():
+    pipeline = ScenePipeline(llm_client=DummyClient())
+    state, reason = pipeline.run_scene(max_turns=3)
+    assert reason == "max_turns"
+    assert state.turn == 3
+
+
+def test_run_scene_times_out():
+    pipeline = ScenePipeline(llm_client=DummyClient())
+    state, reason = pipeline.run_scene(max_duration=0)
+    assert reason == "timeout"
+    assert state.turn == 0


### PR DESCRIPTION
## Summary
- Track elapsed scene time in `ScenePipeline.run_scene`
- Stop running when max turns are reached or the duration limit expires
- Return a termination reason alongside the final scene state
- Test max-turn and timeout behavior in the scene pipeline

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json /tmp/draft-07.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890839ad9048332a3bcc9a689fa64c0