### PR TITLE
feat: add manual stop callback

### DIFF
--- a/backend/scene/pipeline.py
+++ b/backend/scene/pipeline.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Protocol, Tuple
+from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
 import time
 
 from .state import SceneState
@@ -67,6 +67,7 @@ class ScenePipeline:
         *,
         max_turns: Optional[int] = None,
         max_duration: Optional[float] = None,
+        stop_callback: Optional[Callable[[SceneState], bool]] = None,
     ) -> Tuple[SceneState, str]:
         """Run turns until reaching ``max_turns`` or ``max_duration``.
 
@@ -76,6 +77,9 @@ class ScenePipeline:
             Maximum number of turns to execute before stopping.
         max_duration:
             Maximum time in seconds to run before timing out.
+        stop_callback:
+            Callable evaluated after each turn. If it returns a truthy value,
+            the scene stops with reason ``manual_stop``.
 
         Returns
         -------
@@ -104,6 +108,10 @@ class ScenePipeline:
 
             self.state.turn += 1
             turn_count += 1
+
+            if stop_callback is not None and stop_callback(self.state):
+                termination_reason = "manual_stop"
+                break
 
         return self.state, termination_reason
 

--- a/examples/scene_pipeline_demo.py
+++ b/examples/scene_pipeline_demo.py
@@ -2,7 +2,9 @@
 
 This script defines minimal `SceneState` and `ScenePipeline` classes and runs a
 few turns to show how a pipeline might manage state. Responses are selected from
-predefined strings so the demo runs without external dependencies.
+predefined strings so the demo runs without external dependencies. It also
+includes a small example of a ``stop_callback`` that could be passed to
+``run_scene`` in the full pipeline implementation.
 """
 
 from dataclasses import dataclass, field
@@ -35,6 +37,11 @@ class ScenePipeline:
         return response
 
 
+def stop_after_two_turns(state: SceneState) -> bool:
+    """Example callback that stops after two user turns."""
+    return len(state.history) >= 4
+
+
 def main() -> None:
     state = SceneState()
     pipeline = ScenePipeline(state)
@@ -44,9 +51,30 @@ def main() -> None:
         reply = pipeline.run_turn(user_input)
         print(f"Assistant: {reply}")
 
+        if stop_after_two_turns(state):
+            print("Stopping early via callback.")
+            break
+
     print("\nConversation history:")
     for speaker, line in state.history:
         print(f"{speaker}: {line}")
+
+    # Demonstrate how a stop callback could be used with the full pipeline.
+    from backend.scene.pipeline import ScenePipeline as FullPipeline
+
+    class DummyClient:
+        def complete(
+            self, prompt: str, *, model: str, temperature: float
+        ) -> str:
+            return "ok"
+
+    full_pipeline = FullPipeline(llm_client=DummyClient())
+    scene_state, reason = full_pipeline.run_scene(
+        max_turns=5, stop_callback=stop_after_two_turns
+    )
+    print(
+        f"\nFull pipeline stopped at turn {scene_state.turn} due to {reason}."
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_scene_pipeline.py
+++ b/tests/test_scene_pipeline.py
@@ -34,3 +34,16 @@ def test_run_scene_times_out():
     state, reason = pipeline.run_scene(max_duration=0)
     assert reason == "timeout"
     assert state.turn == 0
+
+
+def test_run_scene_manual_stop():
+    pipeline = ScenePipeline(llm_client=DummyClient())
+
+    def stop_after_two(state):
+        return state.turn >= 2
+
+    state, reason = pipeline.run_scene(
+        max_turns=5, stop_callback=stop_after_two
+    )
+    assert reason == "manual_stop"
+    assert state.turn == 2


### PR DESCRIPTION
## Summary
- allow stopping scenes early via `stop_callback`
- document and demonstrate stop callback usage in scene pipeline demo
- cover manual stop behavior with a new test

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json draft7.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890858500a8833293d477e45aa516d7