### PR TITLE
Track scene termination

### DIFF
--- a/backend/scene/pipeline.py
+++ b/backend/scene/pipeline.py
@@ -104,6 +104,23 @@ class ScenePipeline:
 
             self.state.turn += 1
             turn_count += 1
+        final_turn_time = time.time()
+        self.state.history.append(
+            {
+                "event": "final_turn",
+                "turn": self.state.turn,
+                "timestamp": final_turn_time,
+            }
+        )
+        self.state.terminated = True
+        self.state.termination_reason = termination_reason
+        self.state.history.append(
+            {
+                "event": "termination",
+                "reason": termination_reason,
+                "timestamp": time.time(),
+            }
+        )
 
         return self.state, termination_reason
 

--- a/backend/scene/state.py
+++ b/backend/scene/state.py
@@ -14,8 +14,14 @@ class SceneState:
         Ordered list capturing the dialogue and actions that have occurred.
     turn:
         Integer counter tracking the current turn number.
+    terminated:
+        Boolean flag indicating whether the scene has concluded.
+    termination_reason:
+        String describing why the scene ended.
     """
 
     characters: List[str] = field(default_factory=list)
     history: List[Dict[str, Any]] = field(default_factory=list)
     turn: int = 0
+    terminated: bool = False
+    termination_reason: str = ""

--- a/tests/test_scene_pipeline.py
+++ b/tests/test_scene_pipeline.py
@@ -27,6 +27,14 @@ def test_run_scene_respects_max_turns():
     state, reason = pipeline.run_scene(max_turns=3)
     assert reason == "max_turns"
     assert state.turn == 3
+    assert state.terminated is True
+    assert state.termination_reason == "max_turns"
+    assert state.history[-2]["event"] == "final_turn"
+    assert state.history[-2]["turn"] == 3
+    assert "timestamp" in state.history[-2]
+    assert state.history[-1]["event"] == "termination"
+    assert state.history[-1]["reason"] == "max_turns"
+    assert "timestamp" in state.history[-1]
 
 
 def test_run_scene_times_out():
@@ -34,3 +42,11 @@ def test_run_scene_times_out():
     state, reason = pipeline.run_scene(max_duration=0)
     assert reason == "timeout"
     assert state.turn == 0
+    assert state.terminated is True
+    assert state.termination_reason == "timeout"
+    assert state.history[-2]["event"] == "final_turn"
+    assert state.history[-2]["turn"] == 0
+    assert "timestamp" in state.history[-2]
+    assert state.history[-1]["event"] == "termination"
+    assert state.history[-1]["reason"] == "timeout"
+    assert "timestamp" in state.history[-1]


### PR DESCRIPTION
## Summary
- Track whether a scene has ended via `SceneState.terminated` and `termination_reason`
- Log final turn and termination events with timestamps when the scene loop exits
- Test pipeline now verifies final-turn and termination history entries

## Testing
- `curl -L https://json-schema.org/draft-07/schema -o /tmp/draft-07.json && python -m jsonschema -i character_dossier_expanded_method_i.json /tmp/draft-07.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689085985a688332ab93b35682652707