### PR TITLE
Add casting call logging

### DIFF
--- a/backend/casting/models.py
+++ b/backend/casting/models.py
@@ -1,3 +1,5 @@
+"""Data models for the casting pipeline."""
+
 from dataclasses import dataclass, field
 from typing import List
 
@@ -17,3 +19,28 @@ class CharacterCandidate:
 
     name: str
     source_chunks: List[int] = field(default_factory=list)
+
+
+@dataclass
+class CastingCallLog:
+    """Record of a candidate considered during a casting call."""
+
+    candidate: CharacterCandidate
+    selected: bool = False
+
+
+class CastingCallLogStore:
+    """Simple in-memory persistence for ``CastingCallLog`` entries."""
+
+    def __init__(self) -> None:
+        self._logs: List[CastingCallLog] = []
+
+    def add(self, candidate: CharacterCandidate, selected: bool = False) -> None:
+        """Persist a candidate to the log."""
+
+        self._logs.append(CastingCallLog(candidate=candidate, selected=selected))
+
+    def all(self) -> List[CastingCallLog]:
+        """Return all log entries."""
+
+        return list(self._logs)


### PR DESCRIPTION
## Summary
- add `CastingCallLog` model and in-memory store to record casting outcomes
- persist deduplicated candidates from `CharacterExtractionPipeline.run`
- test that `run` writes candidates into the log

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json draft7_schema.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689093810a0c833293f01a43cdeefd54