### PR TITLE
Add casting call candidates endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ This repository hosts design documents for the Method I Narrative Engine. See [R
 
 ## Project Status
 
-Phase 1 delivered the foundational character schemas and the **Living Dossier** system for tracking evolving memories. Phase 2 Task 3 adds the `ScenePipeline`, which consumes dossier data to generate each new scene turn.
+Phase 1 delivered the foundational character schemas and the **Living Dossier**
+system for tracking evolving memories. Phase 2 Task 3 adds the
+`ScenePipeline`, which consumes dossier data to generate each new scene turn.
+Recent work in the casting module introduced a basic API for reviewing
+extracted character candidates.
 
-- [backend/dossier](backend/dossier/README.md) – how living dossiers feed scene generation.
-- [backend/scene](backend/scene/README.md) – pipeline stages for producing dialogue and action.
-- [backend/casting](backend/casting/README.md) – extracts characters from source texts.
+- [backend/dossier](backend/dossier/README.md) – how living dossiers feed scene
+  generation.
+- [backend/scene](backend/scene/README.md) – pipeline stages for producing
+  dialogue and action.
+- [backend/casting](backend/casting/README.md) – extracts characters from source
+  texts and exposes candidate logs via an API.
 
 ## LLM Configuration
 
@@ -78,8 +85,10 @@ chunk_strategy: chapter
 max_chars_per_chunk: 8000
 ```
 
-Its output seeds the `LivingDossier`, which then supplies the
-`ScenePipeline` with character context.
+An in-memory `CastingCallLogStore` captures each extracted candidate. A FastAPI
+route, `GET /casting-call/candidates`, returns these log entries for review.
+Its output seeds the `LivingDossier`, which then supplies the `ScenePipeline`
+with character context.
 
 ## Scene Configuration
 
@@ -102,10 +111,15 @@ manual stop is requested. Defaults originate from `config/scene.yaml` and may
 be overridden with `SCENE_MAX_TURNS`, `SCENE_MAX_DURATION_SECONDS`, or
 equivalent ``run_scene`` arguments.
 
-## Development Progress (Tasks 2–4)
-- **Task 2:** Established the core scene generation loop that retrieves context and constructs prompts.
-- **Task 3:** Wired the loop to an LLM backend and validated parsing of model responses.
-- **Task 4:** Added configuration flags and basic error handling to guard against malformed LLM output.
+## Development Progress
+- **Task 2:** Established the core scene generation loop that retrieves
+  context and constructs prompts.
+- **Task 3:** Wired the loop to an LLM backend and validated parsing of model
+  responses.
+- **Task 4:** Added configuration flags and basic error handling to guard
+  against malformed LLM output.
+- **Phase 3:** Introduced `GET /casting-call/candidates` for reviewing logged
+  character candidates.
 
 ## Environment Variables
 The pipeline expects the following variables at runtime:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,9 @@ Derived from Section 8 of `method_i_doc.txt`, this roadmap outlines the sequenti
    - Build a service or endpoint that ingests text and uses the casting director prompt to return candidate characters.
    - Parse JSON responses from the prompt.
 7. **Implement Review & Selection Logic**
-   - Allow marking which extracted characters to keep, storing selections in memory or a database.
+   - Allow marking which extracted characters to keep, storing selections in
+     memory or a database.
+   - ✅ Provide `GET /casting-call/candidates` to list logged candidates.
 8. **Implement Dossier Compilation**
    - For selected candidates, call the dossier compiler prompt and validate returned JSON against the schema.
    - Persist compiled characters to the Characters database.

--- a/backend/casting/README.md
+++ b/backend/casting/README.md
@@ -28,3 +28,8 @@ Default options live in `config/casting.yaml`:
 The unique candidates produced by this pipeline become initial entries in the
 `LivingDossier`. Those dossiers then supply context for the `ScenePipeline`,
 ensuring dialogue reflects each character's established background.
+
+## API
+
+An in-memory log tracks candidate reviews and backs a FastAPI route.
+`GET /casting-call/candidates` returns all logged entries as JSON.

--- a/backend/casting/api.py
+++ b/backend/casting/api.py
@@ -1,0 +1,21 @@
+"""API endpoints for the casting module."""
+
+from dataclasses import asdict
+
+from fastapi import APIRouter
+
+from .models import CastingCallLogStore
+
+
+router = APIRouter()
+
+# In-memory store for casting call records
+casting_call_log = CastingCallLogStore()
+
+
+@router.get("/casting-call/candidates")
+def get_casting_call_candidates() -> list[dict]:
+    """Return all casting call log entries as JSON."""
+
+    return [asdict(log) for log in casting_call_log.all()]
+

--- a/tests/test_casting_api.py
+++ b/tests/test_casting_api.py
@@ -1,0 +1,25 @@
+"""Tests for casting API endpoints."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.casting.api import casting_call_log, router
+from backend.casting.models import CharacterCandidate
+
+
+def test_get_casting_call_candidates_returns_all_logs() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    casting_call_log._logs.clear()
+    casting_call_log.add(CharacterCandidate(name="Jane"))
+    casting_call_log.add(CharacterCandidate(name="Tom"), selected=True)
+
+    response = client.get("/casting-call/candidates")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"candidate": {"name": "Jane", "source_chunks": []}, "selected": False},
+        {"candidate": {"name": "Tom", "source_chunks": []}, "selected": True},
+    ]
+


### PR DESCRIPTION
## Summary
- add FastAPI router and in-memory log for casting module
- implement `GET /casting-call/candidates` returning all log entries
- cover the new endpoint with unit tests
- document the candidate listing API and mark roadmap progress

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json /tmp/draft-07.json`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689094f938488332949393c53ea40d24