### PR TITLE
Add casting call selection endpoint

### DIFF
--- a/backend/casting/README.md
+++ b/backend/casting/README.md
@@ -31,5 +31,7 @@ ensuring dialogue reflects each character's established background.
 
 ## API
 
-An in-memory log tracks candidate reviews and backs a FastAPI route.
-`GET /casting-call/candidates` returns all logged entries as JSON.
+An in-memory log tracks candidate reviews and backs two FastAPI routes.
+`GET /casting-call/candidates` returns all logged entries as JSON. Use
+`POST /casting-call/select` with a JSON body of `{"selected_ids": [...]}` to
+mark candidates as selected and receive their updated summaries.

--- a/backend/casting/api.py
+++ b/backend/casting/api.py
@@ -3,6 +3,7 @@
 from dataclasses import asdict
 
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 from .models import CastingCallLogStore
 
@@ -18,4 +19,32 @@ def get_casting_call_candidates() -> list[dict]:
     """Return all casting call log entries as JSON."""
 
     return [asdict(log) for log in casting_call_log.all()]
+
+
+class SelectionPayload(BaseModel):
+    """Payload specifying which candidates were selected."""
+
+    selected_ids: list[int]
+
+
+@router.post("/casting-call/select")
+def select_casting_call_candidates(payload: SelectionPayload) -> list[dict]:
+    """Mark candidates as selected and return their summaries.
+
+    The ``selected_ids`` field contains indices into the casting call log. Any
+    candidate whose index appears in that list is marked as selected; all others
+    are cleared. The updated summaries for the selected candidates are returned
+    for confirmation.
+    """
+
+    logs = casting_call_log.all()
+    selected_summaries = []
+    selected_set = set(payload.selected_ids)
+    for idx, log in enumerate(logs):
+        if idx in selected_set:
+            log.selected = True
+            selected_summaries.append(asdict(log))
+        else:
+            log.selected = False
+    return selected_summaries
 

--- a/tests/test_casting_api.py
+++ b/tests/test_casting_api.py
@@ -23,3 +23,25 @@ def test_get_casting_call_candidates_returns_all_logs() -> None:
         {"candidate": {"name": "Tom", "source_chunks": []}, "selected": True},
     ]
 
+
+def test_select_casting_call_candidates_updates_selection() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    casting_call_log._logs.clear()
+    casting_call_log.add(CharacterCandidate(name="Jane"))
+    casting_call_log.add(CharacterCandidate(name="Tom"))
+    casting_call_log.add(CharacterCandidate(name="Lucy"))
+
+    response = client.post(
+        "/casting-call/select", json={"selected_ids": [0, 2]}
+    )
+    assert response.status_code == 200
+    assert response.json() == [
+        {"candidate": {"name": "Jane", "source_chunks": []}, "selected": True},
+        {"candidate": {"name": "Lucy", "source_chunks": []}, "selected": True},
+    ]
+
+    assert [log.selected for log in casting_call_log.all()] == [True, False, True]
+


### PR DESCRIPTION
## Summary
- add POST /casting-call/select to update candidate selection
- document new selection endpoint
- test candidate selection behavior

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json draft-07.json`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890980a2d288332811b72a75c0c2539