### PR TITLE
Validate dossier outputs with jsonschema

### DIFF
--- a/tests/test_dossier_compiler.py
+++ b/tests/test_dossier_compiler.py
@@ -1,0 +1,53 @@
+import pytest
+import jsonschema
+
+from backend.casting.pipeline import DossierCompiler
+from backend.casting.models import CharacterCandidate
+
+
+class DummyLLM:
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.index = 0
+
+    def generate(self, prompt: str):
+        result = self.outputs[self.index]
+        if self.index < len(self.outputs) - 1:
+            self.index += 1
+        return result
+
+
+def test_compile_retries_and_returns_valid(monkeypatch):
+    compiler = DossierCompiler(llm_client=DummyLLM([
+        {"invalid": True},
+        {"valid": True},
+    ]))
+
+    def fake_validate(instance, schema):
+        if instance.get("invalid"):
+            raise jsonschema.ValidationError("invalid")
+
+    monkeypatch.setattr(
+        "backend.casting.pipeline.jsonschema.validate", fake_validate
+    )
+
+    result = compiler.compile(CharacterCandidate(name="Alice", source_chunks=[]))
+    assert result == {"valid": True}
+
+
+def test_compile_raises_after_failures(monkeypatch):
+    compiler = DossierCompiler(llm_client=DummyLLM([
+        {"invalid": True},
+        {"invalid": True},
+    ]))
+
+    def always_fail(instance, schema):
+        raise jsonschema.ValidationError("invalid")
+
+    monkeypatch.setattr(
+        "backend.casting.pipeline.jsonschema.validate", always_fail
+    )
+
+    candidate = CharacterCandidate(name="Bob", source_chunks=[])
+    with pytest.raises(ValueError):
+        compiler.compile(candidate)


### PR DESCRIPTION
## Summary
- validate generated dossiers against `character_dossier_expanded_method_i.json`
- retry or raise a descriptive error if validation fails
- add tests covering dossier validation and retry logic

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json https://json-schema.org/draft-07/schema` *(fails: 'https://json-schema.org/draft-07/schema' does not exist)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689106b37dc48332877fda55e9ec08ed