### PR TITLE
feat: persist character dossiers

### DIFF
--- a/backend/dossier/models.py
+++ b/backend/dossier/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 
 @dataclass
@@ -30,3 +31,40 @@ class LinguisticProfileEntry(_BaseEntry):
 @dataclass
 class LivingDossier(_BaseEntry):
     """High level dossier entry aggregating profile information."""
+
+
+@dataclass
+class Character:
+    """Represents a stored character dossier."""
+
+    character_id: str
+    dossier: Dict[str, Any]
+
+
+class CharacterStore:
+    """Simple in-memory persistence for ``Character`` instances."""
+
+    def __init__(self) -> None:
+        self._characters: Dict[str, Character] = {}
+
+    def insert(self, dossier: Dict[str, Any], character_id: Optional[str] = None) -> str:
+        """Persist ``dossier`` under a unique ``character_id``.
+
+        If ``character_id`` is not supplied, a random UUID4 string is used.
+        """
+
+        cid = character_id or str(uuid4())
+        if cid in self._characters:
+            raise ValueError(f"character_id '{cid}' already exists")
+        self._characters[cid] = Character(character_id=cid, dossier=dossier)
+        return cid
+
+    def get(self, character_id: str) -> Optional[Character]:
+        """Retrieve a stored ``Character`` by its id."""
+
+        return self._characters.get(character_id)
+
+    def all(self) -> List[Character]:
+        """Return all persisted characters."""
+
+        return list(self._characters.values())

--- a/tests/test_character_store.py
+++ b/tests/test_character_store.py
@@ -1,0 +1,21 @@
+import pytest
+
+from backend.dossier.models import CharacterStore
+
+
+def test_insert_and_retrieve_character():
+    store = CharacterStore()
+    dossier = {"name": "Alice"}
+    cid = store.insert(dossier)
+    stored = store.get(cid)
+    assert stored is not None
+    assert stored.dossier == dossier
+
+
+def test_insert_duplicate_id_raises():
+    store = CharacterStore()
+    dossier = {"name": "Bob"}
+    cid = store.insert(dossier, character_id="abc")
+    assert cid == "abc"
+    with pytest.raises(ValueError):
+        store.insert({"name": "Charlie"}, character_id="abc")


### PR DESCRIPTION
## Summary
- define `Character` dataclass and `CharacterStore` to persist dossiers under unique IDs
- add tests for character dossier persistence

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json /tmp/draft-07.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689108811db48332a29b918769a206b5