### PR TITLE
feat: index profile sections

### DIFF
--- a/backend/dossier/living_dossier.py
+++ b/backend/dossier/living_dossier.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Dict, List
 
 from .indexes import ListIndex
+from .models import LinguisticProfileEntry, PsychProfileEntry
 
 
 @dataclass
@@ -16,3 +17,59 @@ class LivingDossier:
 
     def add_linguistic_profile(self, item: Any) -> None:
         self.linguistic_profile_index.add(item)
+
+    def parse_psych_profile(self, dossier: Dict[str, Any]) -> List[PsychProfileEntry]:
+        """Extract ``PsychProfileEntry`` objects from ``dossier``.
+
+        The method looks for an ``inner_world`` section and converts its
+        textual fields and memory journal entries into ``PsychProfileEntry``
+        instances.
+        """
+
+        entries: List[PsychProfileEntry] = []
+        inner_world = dossier.get("inner_world", {})
+
+        for key, value in inner_world.items():
+            if key == "memory_journal" and isinstance(value, list):
+                for idx, item in enumerate(value):
+                    parts = [
+                        f"{sub_key.replace('_', ' ').title()}: {sub_val}"
+                        for sub_key, sub_val in item.items()
+                    ]
+                    content = "; ".join(parts)
+                    entries.append(
+                        PsychProfileEntry(
+                            id=f"memory_journal_{idx}", content=content
+                        )
+                    )
+            elif isinstance(value, str):
+                entries.append(PsychProfileEntry(id=key, content=value))
+
+        return entries
+
+    def parse_linguistic_profile(
+        self, dossier: Dict[str, Any]
+    ) -> List[LinguisticProfileEntry]:
+        """Extract ``LinguisticProfileEntry`` objects from ``dossier``.
+
+        Data is pulled from ``blueprint.linguistic_profile`` and each string
+        field becomes an entry.
+        """
+
+        entries: List[LinguisticProfileEntry] = []
+        blueprint = dossier.get("blueprint", {})
+        profile = blueprint.get("linguistic_profile", {})
+
+        for key, value in profile.items():
+            if isinstance(value, str):
+                entries.append(LinguisticProfileEntry(id=key, content=value))
+
+        return entries
+
+    def store_dossier(self, dossier: Dict[str, Any]) -> None:
+        """Store ``dossier`` and update profile indexes."""
+
+        for entry in self.parse_psych_profile(dossier):
+            self.add_psych_profile(entry)
+        for entry in self.parse_linguistic_profile(dossier):
+            self.add_linguistic_profile(entry)

--- a/tests/test_backend_living_dossier_parsing.py
+++ b/tests/test_backend_living_dossier_parsing.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.dossier.living_dossier import LivingDossier
+from backend.dossier.models import LinguisticProfileEntry, PsychProfileEntry
+
+
+def test_store_dossier_updates_indexes() -> None:
+    dossier = {
+        "inner_world": {
+            "backstory": "A humble origin",
+            "memory_journal": [
+                {
+                    "event": "Saved a cat",
+                    "emotion": "pride",
+                    "sensory_anchor": "soft fur",
+                    "influence_on_present": "compassion",
+                }
+            ],
+            "core_motivation": "Seek justice",
+            "primal_fear": "failure",
+            "primary_defense_mechanism": "humor",
+            "central_paradox": "brave yet fearful",
+            "magic_if": "What if?",
+        },
+        "blueprint": {
+            "linguistic_profile": {
+                "vocabulary_syntax": "formal",
+                "rhythm_imagery": "poetic",
+            }
+        },
+    }
+
+    dossier_store = LivingDossier()
+    dossier_store.store_dossier(dossier)
+
+    psych_items = dossier_store.psych_profile_index._items
+    psych_ids = {e.id for e in psych_items}
+    assert "core_motivation" in psych_ids
+    assert "memory_journal_0" in psych_ids
+    assert len(psych_ids) == 7
+    assert all(isinstance(e, PsychProfileEntry) for e in psych_items)
+
+    ling_items = dossier_store.linguistic_profile_index._items
+    ling_ids = {e.id for e in ling_items}
+    assert ling_ids == {"vocabulary_syntax", "rhythm_imagery"}
+    assert all(isinstance(e, LinguisticProfileEntry) for e in ling_items)


### PR DESCRIPTION
## Summary
- parse inner_world into PsychProfileEntry objects and blueprint.linguistic_profile into LinguisticProfileEntry objects
- update living dossier indexes when storing a dossier
- add regression test for dossier indexing

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json draft7.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910a05ff688332adc4e9965cf18a8b