### PR TITLE
Handle dossier compilation errors per candidate

### DIFF
--- a/backend/casting/api.py
+++ b/backend/casting/api.py
@@ -85,8 +85,9 @@ def compile_casting_call_candidates(payload: CompilePayload) -> list[dict]:
     compiled: list[dict] = []
     for idx in payload.candidate_ids:
         if 0 <= idx < len(logs) and logs[idx].selected:
-            dossier = compiler.compile(logs[idx].candidate)
-            character_store.insert(dossier)
-            compiled.append(dossier)
+            result = compiler.compile(logs[idx].candidate)
+            if "error" not in result:
+                character_store.insert(result)
+            compiled.append(result)
     return compiled
 


### PR DESCRIPTION
## Summary
- log LLM and schema failures in `DossierCompiler` with candidate name and return error payloads instead of raising
- skip storing failed dossiers and return partial results from casting `compile` endpoint
- test dossier compiler and API for per-candidate failures

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json https://json-schema.org/draft-07/schema` *(fails: 'https://json-schema.org/draft-07/schema' does not exist)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910e2e04cc8332b9e82b005b75ffa1