### PR TITLE
docs: update roadmap and introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,88 @@
-# method_i
+# Method I: An Introduction to Character-Driven AI
 
-This repository hosts design documents for the Method I Narrative Engine. See [ROADMAP.md](ROADMAP.md) for the implementation plan derived from section 8 of the main design document.
+Method I is a revolutionary approach to artificial intelligence and
+storytelling that redefines the creative process. At its core, Method I
+is a computational dramaturgy engine that directs improvised dramatic
+scenes between highly structured, AI-powered Characters.
+
+Instead of simulating a generic human mind, Method I models the specific,
+time-tested processes professional actors use to build and perform a
+role. This produces characters with depth, believability, and dramatic
+potential. Our philosophy is simple: the fundamental unit of creativity
+is the **Character**.
+
+## The Method I System: A Two-Part Harmony
+
+The Method I ecosystem comprises two interconnected components:
+
+* **The Method I Acting Training** – a comprehensive system for human
+  actors and AI creators to build and inhabit characters.
+* **The Method I Narrative Engine** – the technological heart of the
+  system, a glass-box architecture that brings characters to life.
+
+### The Two-Phase Character Study Method
+
+The acting training builds a character from the ground up through two
+phases.
+
+**Phase I: Character Formation (The Architect's Work)**
+
+This is deep, foundational work: constructing a complete human being
+through textual analysis, psychological exploration, and physical
+invention.
+
+* **Part A: The Blueprint (Textual Analysis)** – a forensic investigation
+  of the character's script to uncover facts, contradictions, and
+  linguistic fingerprints.
+* **Part B: The Inner World (Psychological & Imaginative Work)** – the
+  character's soul, mind, and history, including motivations, fears, and a
+  sensory-rich memory journal.
+* **Part C: The Physical Form (External Embodiment)** – giving the
+  character a distinct, motivated body using techniques like Animal Work
+  and the Michael Chekhov Technique.
+
+**Phase II: Scene Grounding (The Actor's Work)**
+
+The practical work used during rehearsal and performance to connect with
+the character in the moment.
+
+* **Part A: The Pre-Scene Checklist (Situational Grounding)** – a quick
+  mental checklist for focus, presence, and momentum before a scene
+  begins.
+* **Part B: The In-Scene Activation (Performance Technique)** – actions to
+  stay responsive and alive, playing the action and fully engaging the
+  senses.
+
+## The Method I Narrative Engine
+
+The Narrative Engine manifests the acting training in technology. It is
+a transparent, auditable system that lets creators understand why a
+character behaves a certain way.
+
+### Core Components
+
+* **AI Character Dossier** – the digital blueprint of a character,
+  containing core data, psychological and linguistic profiles, and
+  multimedia assets.
+* **Five-Part Generative Chain** – a process that deconstructs performing
+  a turn into auditable steps: inner monologue, action and dialogue
+  generation, scene analysis, scene closure judgment, and curation.
+* **Dramaturgical RAG System** – a context-aware, emotionally informed
+  retrieval system that lets characters recall relevant aspects of their
+  personality and history.
+
+## The Future Is Character-Driven
+
+Method I shifts how we think about AI and creativity. By treating the
+character as the core creative asset, it fosters a future where creators
+retain control, characters persist across stories, and creativity becomes
+collaborative.
+
+## Repository Overview
+
+This repository hosts design documents for the Method I Narrative Engine.
+See [ROADMAP.md](ROADMAP.md) for the implementation plan derived from
+section 8 of the main design document.
 
 ## Project Status
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,31 +7,37 @@ Derived from Section 8 of `method_i_doc.txt`, this roadmap outlines the sequenti
    - Create JSON or Pydantic models for Character Dossiers, Scene State Manager, Vector Indexes and In-Scene Grounding.
    - Validate example data against these schemas.
    - Set up database tables or JSON columns reflecting the schema structure.
-2. **Implement "Living Dossier" Data Layer**
-   - Establish data stores or placeholders for `psych_profile_index` and `linguistic_profile_index`.
-   - Implement basic retrieval functions for memories and traits until a full vector DB is integrated.
+2. **Implement "Living Dossier" Data Layer** ✅
+   - Establish data stores or placeholders for `psych_profile_index` and
+     `linguistic_profile_index`.
+   - Implement basic retrieval functions for memories and traits until a full
+     vector DB is integrated.
 
 ## Phase 2: Core Logic and LLM Pipeline
-3. **Develop Scene Generation Pipeline**
-   - Implement the turn-by-turn sequence: retrieve context, invoke Inner Monologue LLM, invoke Dialogue & Action LLM, then update state.
+3. **Develop Scene Generation Pipeline** ✅
+   - Implement the turn-by-turn sequence: retrieve context, invoke Inner
+     Monologue LLM, invoke Dialogue & Action LLM, then update state.
    - Integrate the Inner Monologue and Dialogue prompt templates.
    - Parse JSON outputs and update Scene State; test with dummy responses.
-4. **LLM Integration**
+4. **LLM Integration** ✅
    - Connect the pipeline to OpenAI or another LLM provider.
    - Verify prompt formatting and handle errors or timeouts.
-5. **Scene Conclusion Logic (Basic)**
-   - Add a placeholder stopping rule such as max turns or manual stop to avoid infinite loops.
+5. **Scene Conclusion Logic (Basic)** ✅
+   - Add a placeholder stopping rule such as max turns or manual stop to avoid
+     infinite loops.
 
 ## Phase 3: Casting Call Subsystem
-6. **Implement Character Extraction**
-   - Build a service or endpoint that ingests text and uses the casting director prompt to return candidate characters.
+6. **Implement Character Extraction** ✅
+   - Build a service or endpoint that ingests text and uses the casting
+     director prompt to return candidate characters.
    - Parse JSON responses from the prompt.
-7. **Implement Review & Selection Logic**
+7. **Implement Review & Selection Logic** ✅
    - Allow marking which extracted characters to keep, storing selections in
      memory or a database.
-   - ✅ Provide `GET /casting-call/candidates` to list logged candidates.
-8. **Implement Dossier Compilation**
-   - For selected candidates, call the dossier compiler prompt and validate returned JSON against the schema.
+   - Provide `GET /casting-call/candidates` to list logged candidates.
+8. **Implement Dossier Compilation** ✅
+   - For selected candidates, call the dossier compiler prompt and validate
+     returned JSON against the schema.
    - Persist compiled characters to the Characters database.
 9. **Casting Call Integration**
    - Orchestrate extraction, selection and dossier compilation behind a single action or workflow.


### PR DESCRIPTION
## Summary
- mark roadmap tasks 2 through 8 as complete
- add introductory overview of Method I acting training and narrative engine to README

## Testing
- `python -m jsonschema -i character_dossier_expanded_method_i.json draft7_schema.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68918cb3d1e483328d479e95dbbfc4f5